### PR TITLE
Add isEmpty and isNotEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+#### 1.0.1-dev
+   * Added isEmpty and isNotEmpty
+
 #### 1.0.0-dev.1
    * Split from `quiver-dart`

--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ an object graph, like the parent relationship in a tree.
 
 `InfiniteIterable` is a base class for Iterables that throws on operations that
 require a finite length.
+
+`isEmpty`, `isNotEmpty` checks if an iterable is not `null` before checking if
+it's empty or not.

--- a/lib/src/empty.dart
+++ b/lib/src/empty.dart
@@ -12,19 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library quiver.iterables;
+part of quiver.iterables;
 
-import 'dart:collection';
+/// Returns `true` if [i] is null or empty.
+bool isEmpty(Iterable i) => i == null || i.isEmpty;
 
-part 'src/concat.dart';
-part 'src/count.dart';
-part 'src/cycle.dart';
-part 'src/empty.dart';
-part 'src/enumerate.dart';
-part 'src/infinite_iterable.dart';
-part 'src/merge.dart';
-part 'src/min_max.dart';
-part 'src/partition.dart';
-part 'src/generating_iterable.dart';
-part 'src/range.dart';
-part 'src/zip.dart';
+/// Returns `true` if [i] is a non-empty iterable.
+bool isNotEmpty(Iterable i) => i != null && i.isNotEmpty;

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -15,6 +15,7 @@
 import 'concat_test.dart' as concat_test;
 import 'count_test.dart' as count_test;
 import 'cycle_test.dart' as cycle_test;
+import 'empty_test.dart' as empty_test;
 import 'enumerate_test.dart' as enumerate_test;
 import 'generating_iterable_test.dart' as generating_iterable_test;
 import 'merge_test.dart' as merge_test;
@@ -27,6 +28,7 @@ main() {
   concat_test.main();
   count_test.main();
   cycle_test.main();
+  empty_test.main();
   enumerate_test.main();
   generating_iterable_test.main();
   merge_test.main();

--- a/test/concat_test.dart
+++ b/test/concat_test.dart
@@ -15,7 +15,7 @@
 library quiver.iterables.concat_test;
 
 import 'package:test/test.dart';
-import 'package:quiver_iterables/iterables.dart';
+import 'package:quiver_iterables/iterables.dart' hide isEmpty;
 
 main() {
   group('concat', () {

--- a/test/empty_test.dart
+++ b/test/empty_test.dart
@@ -1,0 +1,44 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library quiver.iterables.empty_test;
+
+import 'package:test/test.dart' hide isEmpty, isNotEmpty;
+import 'package:quiver_iterables/iterables.dart';
+
+main() {
+  group('isEmpty', () {
+    test('should consider null to be empty', () {
+      expect(isEmpty(null), isTrue);
+    });
+    test('should consider empty iterable to be empty', () {
+        expect(isEmpty([]), isTrue);
+    });
+    test('should consider non-empty iterable to not be empty', () {
+        expect(isEmpty(['test']), isFalse);
+    });
+  });
+
+  group('isNotEmpty', () {
+    test('should consider null to be empty', () {
+      expect(isNotEmpty(null), isFalse);
+    });
+    test('should consider empty iterable to be empty', () {
+        expect(isNotEmpty([]), isFalse);
+    });
+    test('should consider non-empty iterable to not be empty', () {
+        expect(isNotEmpty(['test']), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
isEmpty and isNotEmpty are very common patterns.  The other quiver APIs provide them and so should iterables.
